### PR TITLE
Adding support for Telegram

### DIFF
--- a/afk_monitor.example.toml
+++ b/afk_monitor.example.toml
@@ -69,3 +69,8 @@ Inactivity = 3          # Warning of no recent journal activity
 # Loading the above with {afk_monitor.py -p MyAltProfile} will override those two settings
 # This feature is most useful for those with multiple accounts or PCs
 # Note: profile, category and setting names are all case-sensitive
+
+[Telegram]
+BotToken = '' # Bot token from BotFather
+
+ChatID = 0 # start a chat with @userinfobot on Telegram and type /start to get your ID


### PR DESCRIPTION
This PR introduces Telegram support, allowing users to receive notifications via Telegram in addition to Discord and terminal output. 
## Features Added
1. **Telegram Integration**:
   - Requires installing the requests library
   - Added support for sending notifications to a Telegram bot.
   - Configurable via the `Telegram` section in the `afk_monitor.toml` configuration file.

2. **New Command-Line Argument**:
   - `--telegram-token`: Allows overriding the Telegram bot token from the command line.

3. **Configuration Updates**:
   - Added `Telegram` section in the configuration file:
     - `BotToken`: The token for the Telegram bot.
     - `ChatID`: The chat ID where messages will be sent.

4. **Error Handling**:
   - Added error handling for Telegram API failures, with appropriate logging.

## Example Configuration
```toml
[Telegram]
BotToken = "your-telegram-bot-token"
ChatID = "your-chat-id"
```
